### PR TITLE
feat: 改进AI对战测试系统和修复bug

### DIFF
--- a/backend/scripts/ai_battle.py
+++ b/backend/scripts/ai_battle.py
@@ -73,11 +73,18 @@ def calculate_elo(
 
 
 def would_cause_draw(game: JieqiGame, move) -> bool:
-    """预判走这步是否会导致和棋"""
+    """预判走这步是否会导致和棋或增加重复局面
+
+    检测：
+    1. 走完后是否立即和棋（重复3次）
+    2. 走完后的局面是否已经出现过（避免走入重复）
+    """
     game.make_move(move)
     is_draw = game.result == GameResult.DRAW
+    # 检查当前局面是否已经出现过（出现2次就危险了）
+    is_repeated = game.get_position_count() >= 2
     game.undo_move()
-    return is_draw
+    return is_draw or is_repeated
 
 
 def run_single_game(

--- a/backend/scripts/debug_draw.py
+++ b/backend/scripts/debug_draw.py
@@ -1,0 +1,75 @@
+"""调试为什么某些对局4步就和棋"""
+
+from jieqi.ai import AIEngine
+from jieqi.ai.base import AIConfig
+from jieqi.game import GameConfig, JieqiGame
+from jieqi.types import Color, GameResult
+
+
+def debug_game(seed: int, red_time: float = 0.15, black_time: float = 5.0):
+    """调试单局对战"""
+    red_ai = AIEngine.create("advanced", AIConfig(time_limit=red_time, seed=seed * 1000))
+    black_ai = AIEngine.create(
+        "advanced", AIConfig(time_limit=black_time, seed=seed * 1000 + 1)
+    )
+    game = JieqiGame(config=GameConfig(seed=seed))
+
+    print(f"=== Debug Game seed={seed} ===")
+    print(f"Initial position count: {game.get_position_count()}")
+
+    moves = 0
+    max_moves = 10
+
+    while game.result == GameResult.ONGOING and moves < max_moves:
+        current = game.current_turn
+        ai = red_ai if current == Color.RED else black_ai
+        view = game.get_view(current)
+
+        candidates = ai.select_moves(view, n=10)
+        print(f"\nMove {moves + 1} ({current.name}):")
+        print(f"  Candidates: {len(candidates)}")
+
+        # 检查每个候选是否会导致和棋
+        for i, (move, score) in enumerate(candidates[:5]):
+            game.make_move(move)
+            is_draw = game.result == GameResult.DRAW
+            pos_count = game.get_position_count()
+            game.undo_move()
+            print(f"  [{i}] {move} score={score:.0f} would_draw={is_draw} pos_count_after={pos_count}")
+
+        # 选择第一个不会导致和棋的
+        move = None
+        for candidate_move, _score in candidates:
+            game.make_move(candidate_move)
+            is_draw = game.result == GameResult.DRAW
+            is_repeated = game.get_position_count() >= 2
+            game.undo_move()
+            if not (is_draw or is_repeated):
+                move = candidate_move
+                break
+
+        if move is None and candidates:
+            move = candidates[0][0]
+            print(f"  -> All candidates would cause draw/repeat, using first: {move}")
+
+        if move is None:
+            print("  -> No move available!")
+            break
+
+        game.make_move(move)
+        moves += 1
+
+        history = game.get_move_history()
+        if history:
+            notation = history[-1].get("notation", "?")
+            print(f"  -> Played: {notation}")
+            print(f"  -> Position count: {game.get_position_count()}")
+            print(f"  -> Game result: {game.result}")
+
+    print(f"\n=== Final: {game.result.name} after {moves} moves ===")
+
+
+if __name__ == "__main__":
+    debug_game(17)
+    print("\n" + "=" * 60 + "\n")
+    debug_game(20)

--- a/backend/scripts/replay_game.py
+++ b/backend/scripts/replay_game.py
@@ -1,0 +1,74 @@
+"""重放一局对战，查看结束原因"""
+
+from jieqi.ai import AIEngine
+from jieqi.ai.base import AIConfig
+from jieqi.game import GameConfig, JieqiGame
+from jieqi.types import Color, GameResult
+
+
+def replay_game(seed: int, red_time: float = 1.5, black_time: float = 15.0, max_moves: int = 20):
+    """重放一局对战"""
+    red_ai = AIEngine.create("advanced", AIConfig(time_limit=red_time, seed=seed * 1000))
+    black_ai = AIEngine.create(
+        "advanced", AIConfig(time_limit=black_time, seed=seed * 1000 + 1)
+    )
+    game = JieqiGame(config=GameConfig(seed=seed))
+
+    print(f"=== Replay Game seed={seed} ===")
+    print(f"Red: {red_time}s, Black: {black_time}s")
+
+    moves = 0
+
+    while game.result == GameResult.ONGOING and moves < max_moves:
+        current = game.current_turn
+        ai = red_ai if current == Color.RED else black_ai
+        view = game.get_view(current)
+
+        print(f"\nMove {moves + 1} ({current.name}):")
+        print(f"  Legal moves: {len(view.legal_moves)}")
+
+        candidates = ai.select_moves(view, n=3)
+        if not candidates:
+            print("  No candidates!")
+            break
+
+        move = candidates[0][0]
+        game.make_move(move)
+        moves += 1
+
+        history = game.get_move_history()
+        if history:
+            notation = history[-1].get("notation", "?")
+            print(f"  Played: {notation}")
+
+        print(f"  Result: {game.result.name}")
+
+        # 如果游戏结束，打印棋盘状态
+        if game.result != GameResult.ONGOING:
+            print("\n=== Game Over ===")
+            print(f"Result: {game.result.name}")
+            # 打印简单的棋盘表示
+            board = game.board
+            print("\nFinal board (viewer: RED):")
+            red_view = game.get_view(Color.RED)
+            for row in range(10):
+                line = ""
+                for col in range(9):
+                    from jieqi.types import Position
+                    pos = Position(row, col)
+                    piece = board.get_piece(pos)
+                    if piece:
+                        if piece.is_hidden:
+                            line += "? "
+                        else:
+                            line += f"{piece.piece_type.value[0]} "
+                    else:
+                        line += ". "
+                print(line)
+            break
+
+
+if __name__ == "__main__":
+    import sys
+    seed = int(sys.argv[1]) if len(sys.argv) > 1 else 9
+    replay_game(seed)

--- a/backend/scripts/show_board.py
+++ b/backend/scripts/show_board.py
@@ -1,0 +1,106 @@
+"""显示某局某步的棋盘状态"""
+
+from jieqi.ai import AIEngine
+from jieqi.ai.base import AIConfig
+from jieqi.game import GameConfig, JieqiGame
+from jieqi.types import Color, GameResult, PieceType
+
+
+# 棋子符号映射
+PIECE_SYMBOLS = {
+    # 红方
+    (Color.RED, PieceType.KING): "帥",
+    (Color.RED, PieceType.ADVISOR): "仕",
+    (Color.RED, PieceType.ELEPHANT): "相",
+    (Color.RED, PieceType.HORSE): "傌",
+    (Color.RED, PieceType.ROOK): "俥",
+    (Color.RED, PieceType.CANNON): "炮",
+    (Color.RED, PieceType.PAWN): "兵",
+    # 黑方
+    (Color.BLACK, PieceType.KING): "將",
+    (Color.BLACK, PieceType.ADVISOR): "士",
+    (Color.BLACK, PieceType.ELEPHANT): "象",
+    (Color.BLACK, PieceType.HORSE): "馬",
+    (Color.BLACK, PieceType.ROOK): "車",
+    (Color.BLACK, PieceType.CANNON): "砲",
+    (Color.BLACK, PieceType.PAWN): "卒",
+}
+
+
+def show_board(game: JieqiGame):
+    """打印棋盘 ASCII"""
+    board = game.board
+    print("\n  ９ ８ ７ ６ ５ ４ ３ ２ １")
+    print("  ─────────────────────────")
+
+    for row in range(10):
+        line = f"{row}│"
+        for col in range(9):
+            from jieqi.types import Position
+            pos = Position(row, col)
+            piece = board.get_piece(pos)
+            if piece:
+                if piece.is_hidden:
+                    line += "？"
+                else:
+                    symbol = PIECE_SYMBOLS.get((piece.color, piece.actual_type), "?")
+                    line += symbol
+            else:
+                line += "・"
+            line += " " if col < 8 else ""
+        line += "│"
+        print(line)
+
+    print("  ─────────────────────────")
+    print(f"  当前回合: {game.current_turn.name}, 结果: {game.result.name}")
+
+
+def replay_to_move(seed: int, target_move: int, red_time: float = 1.5, black_time: float = 15.0):
+    """重放到指定步数"""
+    red_ai = AIEngine.create("advanced", AIConfig(time_limit=red_time, seed=seed * 1000))
+    black_ai = AIEngine.create(
+        "advanced", AIConfig(time_limit=black_time, seed=seed * 1000 + 1)
+    )
+    game = JieqiGame(config=GameConfig(seed=seed))
+
+    print(f"=== Game seed={seed}, replay to move {target_move} ===")
+
+    # 先显示初始棋盘
+    if target_move == 0:
+        print("\n初始棋盘:")
+        show_board(game)
+        return
+
+    for move_num in range(target_move):
+        current = game.current_turn
+        ai = red_ai if current == Color.RED else black_ai
+        view = game.get_view(current)
+
+        candidates = ai.select_moves(view, n=1)
+        if not candidates:
+            print(f"Move {move_num + 1}: No candidates!")
+            break
+
+        move = candidates[0][0]
+        game.make_move(move)
+
+        history = game.get_move_history()
+        notation = history[-1].get("notation", "?") if history else "?"
+        color = "红" if current == Color.RED else "黑"
+
+        print(f"Move {move_num + 1}: [{color}] {notation}")
+
+        if game.result != GameResult.ONGOING:
+            print(f"\n游戏结束: {game.result.name}")
+            show_board(game)
+            return
+
+    print(f"\n第 {target_move} 步后的棋盘:")
+    show_board(game)
+
+
+if __name__ == "__main__":
+    import sys
+    seed = int(sys.argv[1]) if len(sys.argv) > 1 else 9
+    target_move = int(sys.argv[2]) if len(sys.argv) > 2 else 11
+    replay_to_move(seed, target_move)

--- a/backend/scripts/time_battle_test.py
+++ b/backend/scripts/time_battle_test.py
@@ -1,0 +1,208 @@
+"""
+不同时间限制的 AI 对战测试
+"""
+
+import json
+import multiprocessing as mp
+import os
+import sys
+import time
+from pathlib import Path
+
+from jieqi.ai import AIEngine
+from jieqi.ai.base import AIConfig
+from jieqi.game import GameConfig, JieqiGame
+from jieqi.types import Color, GameResult
+
+# 棋谱保存目录
+GAME_LOG_DIR = Path(__file__).parent.parent / "data" / "battle_logs"
+GAME_LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def would_cause_draw(game: JieqiGame, move) -> bool:
+    """预判走这步是否会导致和棋或增加重复局面"""
+    game.make_move(move)
+    is_draw = game.result == GameResult.DRAW
+    is_repeated = game.get_position_count() >= 2
+    game.undo_move()
+    return is_draw or is_repeated
+
+
+def run_single_game(args):
+    """单局对战，返回结果和棋谱"""
+    red_time, black_time, seed = args
+    red_ai = AIEngine.create("advanced", AIConfig(time_limit=red_time, seed=seed * 1000))
+    black_ai = AIEngine.create(
+        "advanced", AIConfig(time_limit=black_time, seed=seed * 1000 + 1)
+    )
+    # 给棋盘也传入 seed，确保可复现
+    game = JieqiGame(config=GameConfig(seed=seed))
+    moves = 0
+    max_moves = 500
+
+    # 记录棋谱
+    notations = []
+
+    while game.result == GameResult.ONGOING and moves < max_moves:
+        current = game.current_turn
+        ai = red_ai if current == Color.RED else black_ai
+        view = game.get_view(current)
+
+        # 使用 Top-N 候选，规避和棋
+        move = None
+        candidates = ai.select_moves(view, n=10)
+        for candidate_move, _score in candidates:
+            if not would_cause_draw(game, candidate_move):
+                move = candidate_move
+                break
+        if move is None and candidates:
+            move = candidates[0][0]
+
+        if move is None:
+            # AI 无法返回着法，视为该方输（对方赢）
+            if current == Color.RED:
+                result = "black"
+            else:
+                result = "red"
+            notations.append(f"# [{current.name}] AI returned no moves")
+            return (seed, result, moves, notations)
+
+        game.make_move(move)
+        moves += 1
+
+        # 记录棋谱
+        history = game.get_move_history()
+        if history:
+            notation = history[-1].get("notation", "?")
+            color = "红" if current == Color.RED else "黑"
+            notations.append(f"{moves}. [{color}] {notation}")
+
+    if game.result == GameResult.RED_WIN:
+        result = "red"
+    elif game.result == GameResult.BLACK_WIN:
+        result = "black"
+    else:
+        result = "draw"
+        notations.append(f"# Draw: {game.result.name}")
+
+    return (seed, result, moves, notations)
+
+
+def battle_with_progress(red_time, black_time, games=100, workers=None, log_file=None):
+    """并行对战测试，带实时进度输出和棋谱记录"""
+    if workers is None:
+        workers = max(1, int(os.cpu_count() * 0.7))
+
+    args = [(red_time, black_time, i) for i in range(games)]
+
+    red_wins = 0
+    black_wins = 0
+    draws = 0
+    total_moves = 0
+    completed = 0
+
+    # 所有棋谱
+    all_games = []
+
+    print(f"Starting {games} games with {workers} workers...", flush=True)
+    print(f"Logs will be saved to: {log_file}", flush=True)
+    print("-" * 60, flush=True)
+
+    with mp.Pool(workers) as pool:
+        # 使用 imap_unordered 实时获取结果
+        for seed, result, moves, notations in pool.imap_unordered(run_single_game, args):
+            completed += 1
+            total_moves += moves
+
+            if result == "red":
+                red_wins += 1
+                symbol = "R"
+            elif result == "black":
+                black_wins += 1
+                symbol = "B"
+            else:
+                draws += 1
+                symbol = "D"
+
+            # 记录这局棋谱
+            game_record = {
+                "seed": seed,
+                "result": result,
+                "moves": moves,
+                "notations": notations,
+            }
+            all_games.append(game_record)
+
+            # 每局输出一行日志
+            win_rate = (
+                black_wins / (red_wins + black_wins) * 100
+                if (red_wins + black_wins) > 0
+                else 0
+            )
+            print(
+                f"[{completed:3d}/{games}] Game {seed:3d}: {symbol} ({moves:3d} moves) | "
+                f"R:{red_wins} B:{black_wins} D:{draws} | "
+                f"Long time win rate: {win_rate:.1f}%",
+                flush=True,
+            )
+
+            # 实时保存棋谱到文件
+            if log_file:
+                save_data = {
+                    "config": {
+                        "red_time": red_time,
+                        "black_time": black_time,
+                        "total_games": games,
+                    },
+                    "progress": {
+                        "completed": completed,
+                        "red_wins": red_wins,
+                        "black_wins": black_wins,
+                        "draws": draws,
+                    },
+                    "games": sorted(all_games, key=lambda x: x["seed"]),
+                }
+                with open(log_file, "w") as f:
+                    json.dump(save_data, f, ensure_ascii=False, indent=2)
+
+    avg_moves = total_moves / games
+    return red_wins, black_wins, draws, avg_moves, all_games
+
+
+if __name__ == "__main__":
+    cpu_count = os.cpu_count()
+    workers = max(1, int(cpu_count * 0.7))
+
+    # 可以通过命令行参数指定
+    red_time = float(sys.argv[1]) if len(sys.argv) > 1 else 0.15
+    black_time = float(sys.argv[2]) if len(sys.argv) > 2 else 5
+    games = int(sys.argv[3]) if len(sys.argv) > 3 else 100
+
+    # 日志文件
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    log_file = GAME_LOG_DIR / f"battle_{red_time}s_vs_{black_time}s_{timestamp}.json"
+
+    print(f"CPU: {cpu_count} cores, using {workers} workers")
+    print("=" * 60)
+    print(f"Battle: {red_time}s (Red) vs {black_time}s (Black)")
+    print(f"Games: {games}")
+    print("=" * 60)
+
+    start = time.time()
+    r, b, d, avg, all_games = battle_with_progress(
+        red_time, black_time, games, workers, log_file
+    )
+    elapsed = time.time() - start
+
+    print("=" * 60)
+    print("FINAL RESULTS")
+    print("=" * 60)
+    print(f"Red({red_time}s): {r} wins")
+    print(f"Black({black_time}s): {b} wins")
+    print(f"Draws: {d}")
+    print(f"Avg moves: {avg:.0f}")
+    print(f"Elapsed: {elapsed:.0f}s")
+    if r + b > 0:
+        print(f"\nLonger time ({black_time}s) win rate: {b / (r + b) * 100:.1f}%")
+    print(f"Draw rate: {d / games * 100:.1f}%")
+    print(f"\nGame logs saved to: {log_file}")


### PR DESCRIPTION
## 概述
改进AI对战测试系统，修复若干bug，添加调试工具。

## 主要改动

### AI策略改进 (v014_advanced)
- 时间控制模式下允许更深搜索深度 (`max_depth=30`)，让时间来控制搜索
- 确保 depth 1 必须完成，避免极端情况下返回空候选
- 搜索超时时回退到随机合法着法，而非返回空
- 添加评估分数归一化函数，将分数压缩到 `-1000 ~ 1000` 范围

### 新增对战测试脚本
- `time_battle_test.py`: 不同时间限制的AI对战测试
  - 支持实时进度输出
  - 棋谱记录保存到JSON
  - 修复AI无候选着法时错误判定为和棋的bug

### 调试工具
- `debug_draw.py`: 调试和棋问题
- `replay_game.py`: 重放指定对局
- `show_board.py`: ASCII棋盘显示

## 测试结果
1.5s vs 15s 对战测试（50局）:
- 15秒版本胜率约 63-65%
- 和棋率极低（真正的和棋）

🤖 Generated with [Claude Code](https://claude.com/claude-code)