### PR TITLE
chore: 添加battle_logs到gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ Thumbs.db
 # Project specific
 logs/
 *.log
+backend/data/battle_logs/
 .call_count
 .circuit_breaker_history
 .circuit_breaker_state


### PR DESCRIPTION
## 概述
忽略AI对战测试产生的日志文件。

## 改动
- 将 `backend/data/battle_logs/` 添加到 .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)