### PR TITLE
改进前端UI和AI体验

### DIFF
--- a/backend/jieqi/ai/evaluator.py
+++ b/backend/jieqi/ai/evaluator.py
@@ -1,0 +1,492 @@
+"""
+揭棋 AI 评估器
+
+参考 miaosisrai 的设计思路，提供统一的评分系统:
+- 分数范围: -1000 到 1000
+- 正分表示当前玩家优势，负分表示劣势
+- 可以转换为胜率 (win rate)
+
+核心思路:
+1. Position Score Table (PST): 每个棋子在每个位置的价值
+2. 暗子期望价值: 根据剩余可能棋子计算期望值
+3. 揭棋特有战术评估: 空头炮、沉底炮、肋道车等
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from jieqi.types import Color, PieceType, Position
+
+if TYPE_CHECKING:
+    from jieqi.simulation import SimulationBoard, SimPiece
+
+
+# ============================================================================
+# 棋子基础价值 (参考 miaosisrai 的设定)
+# ============================================================================
+# 这些值经过调整，使得最终评分在合理范围内
+
+PIECE_BASE_VALUES = {
+    PieceType.KING: 2500,  # 将/帅 - 无价
+    PieceType.ROOK: 233,  # 车 - 最强
+    PieceType.CANNON: 101,  # 炮
+    PieceType.HORSE: 108,  # 马
+    PieceType.ELEPHANT: 23,  # 象
+    PieceType.ADVISOR: 23,  # 士
+    PieceType.PAWN: 44,  # 兵/卒
+}
+
+# 兵过河后价值提升
+PAWN_CROSSED_RIVER_BONUS = 30
+
+
+# ============================================================================
+# 位置价值表 (PST - Position Score Tables)
+# 参考 miaosisrai 的 common.py，适配我们的 10x9 棋盘
+# ============================================================================
+
+# 兵/卒位置表 (红方视角，row 0-9，col 0-8)
+PST_PAWN = [
+    # row 0 (红方底线)
+    [2, 2, 3, -9, -12, -9, 3, 2, 2],
+    [4, 4, 5, -6, -10, -6, 5, 4, 4],
+    [5, 5, 6, 4, 5, 4, 6, 5, 5],
+    [13, 13, 14, 14, 15, 14, 14, 13, 13],
+    [24, 35, 20, 27, 29, 27, 20, 35, 24],  # row 4
+    # row 5 (过河线)
+    [34, 55, 37, 37, 39, 37, 37, 55, 34],
+    [47, 57, 47, 49, 60, 49, 47, 57, 47],
+    [60, 74, 74, 79, 97, 79, 74, 74, 60],
+    [75, 84, 89, 101, 113, 101, 89, 84, 75],
+    [75, 84, 85, 87, 87, 87, 85, 84, 75],  # row 9 (黑方底线)
+]
+
+# 相/象位置表
+PST_ELEPHANT = [
+    [35, 16, 40, 16, 20, 16, 40, 16, 35],  # row 0
+    [55, 27, 6, 27, 30, 27, 6, 27, 55],
+    [35, 30, 49, 30, 43, 30, 49, 30, 35],
+    [10, 35, 65, 35, 10, 35, 65, 35, 10],
+    [60, 30, 31, 30, 65, 30, 31, 30, 60],  # row 4
+    [65, 35, 12, 35, 70, 35, 12, 35, 65],
+    [27, 31, 70, 30, 25, 30, 70, 31, 27],
+    [12, 41, 75, 41, 6, 41, 75, 41, 12],
+    [65, 55, 15, 20, 68, 20, 15, 55, 65],
+    [70, 39, 12, 35, 72, 35, 12, 39, 70],  # row 9
+]
+
+# 士/仕位置表
+PST_ADVISOR = [
+    [65, 92, 57, 104, 55, 104, 57, 92, 65],  # row 0
+    [65, 57, 95, 69, 105, 69, 95, 57, 65],
+    [69, 90, 65, 100, 61, 100, 65, 90, 69],
+    [82, 69, 89, 69, 93, 69, 89, 69, 82],
+    [73, 85, 75, 85, 75, 85, 75, 85, 73],  # row 4
+    [81, 82, 85, 82, 85, 82, 85, 82, 81],
+    [83, 85, 88, 86, 88, 86, 88, 85, 83],
+    [85, 109, 88, 91, 88, 91, 88, 109, 85],
+    [88, 88, 99, 109, 106, 109, 99, 88, 88],
+    [88, 103, 92, 115, 100, 115, 92, 103, 88],  # row 9
+]
+
+# 马位置表
+PST_HORSE = [
+    [85, 85, 90, 105, 95, 105, 90, 85, 85],  # row 0
+    [99, 105, 99, 99, 99, 99, 99, 105, 99],
+    [113, 113, 114, 115, 125, 115, 114, 113, 113],
+    [112, 114, 118, 115, 118, 115, 118, 114, 112],
+    [110, 118, 121, 122, 122, 122, 121, 118, 110],  # row 4
+    [110, 120, 133, 133, 140, 133, 133, 120, 110],
+    [113, 138, 122, 135, 120, 135, 122, 138, 113],
+    [117, 113, 114, 153, 129, 153, 114, 113, 117],
+    [120, 126, 153, 117, 124, 117, 153, 126, 120],
+    [138, 120, 120, 126, 120, 126, 120, 120, 138],  # row 9
+]
+
+# 车位置表
+PST_ROOK = [
+    [274, 276, 274, 282, 250, 282, 274, 276, 274],  # row 0
+    [270, 278, 276, 289, 260, 289, 276, 278, 270],
+    [268, 274, 274, 289, 272, 289, 274, 274, 268],
+    [274, 274, 274, 287, 284, 287, 274, 274, 274],
+    [278, 272, 282, 287, 285, 287, 282, 272, 278],  # row 4
+    [278, 281, 281, 287, 285, 287, 281, 281, 278],
+    [280, 282, 282, 289, 286, 289, 282, 282, 280],
+    [280, 282, 282, 289, 296, 289, 282, 282, 280],
+    [280, 282, 282, 289, 303, 289, 282, 282, 280],
+    [316, 318, 318, 326, 324, 326, 318, 318, 316],  # row 9 (底线车更强)
+]
+
+# 炮位置表
+PST_CANNON = [
+    [126, 126, 127, 129, 129, 129, 127, 126, 126],  # row 0
+    [126, 127, 128, 128, 135, 128, 128, 127, 126],
+    [127, 126, 100, 129, 140, 129, 100, 126, 127],
+    [126, 126, 126, 126, 140, 126, 126, 126, 126],
+    [125, 126, 129, 126, 130, 126, 129, 126, 125],  # row 4
+    [126, 126, 126, 126, 130, 126, 126, 126, 126],
+    [126, 129, 129, 128, 130, 128, 129, 129, 126],
+    [127, 127, 126, 121, 122, 121, 126, 127, 127],
+    [128, 138, 126, 122, 129, 122, 126, 138, 128],
+    [195, 195, 192, 182, 170, 182, 192, 195, 195],  # row 9 (沉底炮价值)
+]
+
+# 将/帅位置表 (九宫内)
+PST_KING = [
+    [2460, 2500, 2460, 0, 0, 0, 0, 0, 0],  # row 0 (红方底线)
+    [2420, 2460, 2420, 0, 0, 0, 0, 0, 0],
+    [2380, 2420, 2380, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 2380, 2420, 2380],  # row 7 (黑方九宫开始)
+    [0, 0, 0, 0, 0, 0, 2420, 2460, 2420],
+    [0, 0, 0, 0, 0, 0, 2460, 2500, 2460],  # row 9 (黑方底线)
+]
+
+# PST 映射
+PST_TABLES = {
+    PieceType.PAWN: PST_PAWN,
+    PieceType.ELEPHANT: PST_ELEPHANT,
+    PieceType.ADVISOR: PST_ADVISOR,
+    PieceType.HORSE: PST_HORSE,
+    PieceType.ROOK: PST_ROOK,
+    PieceType.CANNON: PST_CANNON,
+    PieceType.KING: PST_KING,
+}
+
+
+# ============================================================================
+# 暗子期望价值计算
+# ============================================================================
+
+
+@dataclass
+class HiddenPieceDistribution:
+    """暗子分布统计
+
+    跟踪每种棋子还剩余多少可能是暗子的数量
+    """
+
+    # 每种棋子类型剩余可能数量
+    remaining: dict[PieceType, int] = field(
+        default_factory=lambda: {
+            PieceType.ROOK: 2,
+            PieceType.HORSE: 2,
+            PieceType.ELEPHANT: 2,
+            PieceType.ADVISOR: 2,
+            PieceType.CANNON: 2,
+            PieceType.PAWN: 5,
+        }
+    )
+
+    def total_remaining(self) -> int:
+        """剩余暗子总数"""
+        return sum(self.remaining.values())
+
+    def get_expected_value(self, position: Position, color: Color) -> float:
+        """计算某位置暗子的期望价值
+
+        基于剩余可能棋子的加权平均值
+        """
+        total = self.total_remaining()
+        if total == 0:
+            return 0.0
+
+        expected = 0.0
+        for piece_type, count in self.remaining.items():
+            if count > 0:
+                prob = count / total
+                # 基础价值
+                value = PIECE_BASE_VALUES.get(piece_type, 0)
+                # 位置价值
+                pst = PST_TABLES.get(piece_type)
+                if pst:
+                    row, col = position.row, position.col
+                    # 黑方需要翻转视角
+                    if color == Color.BLACK:
+                        row = 9 - row
+                    if 0 <= row < 10 and 0 <= col < 9:
+                        value = pst[row][col]
+
+                expected += prob * value
+
+        return expected
+
+    def get_average_value(self) -> float:
+        """获取暗子的平均价值（不考虑位置）"""
+        total = self.total_remaining()
+        if total == 0:
+            return 0.0
+
+        weighted_sum = 0.0
+        for piece_type, count in self.remaining.items():
+            if count > 0:
+                weighted_sum += count * PIECE_BASE_VALUES.get(piece_type, 0)
+
+        return weighted_sum / total
+
+
+# ============================================================================
+# 评估器主类
+# ============================================================================
+
+
+class JieqiEvaluator:
+    """揭棋评估器
+
+    提供统一的评分系统，分数范围 -1000 到 1000
+    """
+
+    # 用于分数归一化的缩放因子
+    # 按照 miaosisrai 的设计，满子力约 2000+ 分，设置缩放因子使其映射到合理范围
+    SCORE_SCALE = 500.0
+
+    # 杀棋分数
+    MATE_SCORE = 10000
+
+    def __init__(self) -> None:
+        self._red_hidden = HiddenPieceDistribution()
+        self._black_hidden = HiddenPieceDistribution()
+
+    def reset_distribution(self) -> None:
+        """重置暗子分布"""
+        self._red_hidden = HiddenPieceDistribution()
+        self._black_hidden = HiddenPieceDistribution()
+
+    def get_piece_value(self, piece: SimPiece) -> float:
+        """获取棋子价值（包含位置评估）"""
+        if piece.is_hidden:
+            # 暗子使用期望价值
+            dist = self._red_hidden if piece.color == Color.RED else self._black_hidden
+            return dist.get_expected_value(piece.position, piece.color)
+
+        if piece.actual_type is None:
+            # 未知类型（不应该发生）
+            return 100.0
+
+        # 使用 PST 获取位置价值
+        pst = PST_TABLES.get(piece.actual_type)
+        if pst:
+            row, col = piece.position.row, piece.position.col
+            # 黑方需要翻转视角
+            if piece.color == Color.BLACK:
+                row = 9 - row
+            if 0 <= row < 10 and 0 <= col < 9:
+                return float(pst[row][col])
+
+        # 无 PST 时使用基础价值
+        return float(PIECE_BASE_VALUES.get(piece.actual_type, 0))
+
+    def evaluate(self, board: SimulationBoard, color: Color) -> float:
+        """评估局面
+
+        返回当前玩家视角的评分（正分优势，负分劣势）
+        """
+        score = 0.0
+
+        my_pieces = board.get_all_pieces(color)
+        enemy_pieces = board.get_all_pieces(color.opposite)
+
+        # 检查是否有将/帅
+        my_king = board.find_king(color)
+        enemy_king = board.find_king(color.opposite)
+
+        if my_king is None:
+            return -self.MATE_SCORE
+        if enemy_king is None:
+            return self.MATE_SCORE
+
+        # 1. 子力价值
+        for piece in my_pieces:
+            score += self.get_piece_value(piece)
+
+        for piece in enemy_pieces:
+            score -= self.get_piece_value(piece)
+
+        # 2. 将军评估
+        if board.is_in_check(color.opposite):
+            score += 50  # 将军对方
+        if board.is_in_check(color):
+            score -= 50  # 被将军
+
+        # 3. 揭棋特有评估
+        score += self._evaluate_jieqi_tactics(board, color)
+
+        # 4. 机动性评估
+        my_mobility = self._count_moves(board, color)
+        enemy_mobility = self._count_moves(board, color.opposite)
+        score += (my_mobility - enemy_mobility) * 2
+
+        return score
+
+    def _evaluate_jieqi_tactics(self, board: SimulationBoard, color: Color) -> float:
+        """评估揭棋特有战术"""
+        score = 0.0
+
+        my_pieces = board.get_all_pieces(color)
+        enemy_pieces = board.get_all_pieces(color.opposite)
+
+        # 统计暗子数量
+        my_hidden = sum(1 for p in my_pieces if p.is_hidden)
+        enemy_hidden = sum(1 for p in enemy_pieces if p.is_hidden)
+
+        # 开局阶段暗子多是优势（保持神秘感）
+        total_pieces = len(my_pieces) + len(enemy_pieces)
+        if total_pieces > 24:
+            score += (my_hidden - enemy_hidden) * 5
+
+        # 检查空头炮（炮瞄准对方将/帅，中间没有棋子）
+        score += self._evaluate_kongtoupao(board, color)
+
+        # 车的活跃度
+        for piece in my_pieces:
+            if not piece.is_hidden and piece.actual_type == PieceType.ROOK:
+                # 车占据中路
+                if piece.position.col == 4:
+                    score += 30
+                # 车占据肋道（第4列或第6列）
+                if piece.position.col in [3, 5]:
+                    score += 20
+
+        return score
+
+    def _evaluate_kongtoupao(self, board: SimulationBoard, color: Color) -> float:
+        """评估空头炮
+
+        空头炮：炮瞄准对方将/帅，中间只有炮自己
+        """
+        score = 0.0
+
+        my_pieces = board.get_all_pieces(color)
+        enemy_king = board.find_king(color.opposite)
+
+        if enemy_king is None:
+            return 0.0
+
+        for piece in my_pieces:
+            if not piece.is_hidden and piece.actual_type == PieceType.CANNON:
+                # 检查是否在同一列
+                if piece.position.col == enemy_king.col:
+                    # 检查中间是否只有己方棋子或没有棋子
+                    is_kongtou = True
+                    piece_count = 0
+                    start_row = min(piece.position.row, enemy_king.row) + 1
+                    end_row = max(piece.position.row, enemy_king.row)
+
+                    for row in range(start_row, end_row):
+                        target = board.get_piece(Position(row, piece.position.col))
+                        if target is not None:
+                            piece_count += 1
+                            if target.color != color:
+                                is_kongtou = False
+                                break
+
+                    if is_kongtou and piece_count == 0:
+                        score += 70  # 空头炮价值
+                        # 如果己方有车配合，价值更高
+                        my_rooks = [
+                            p
+                            for p in my_pieces
+                            if not p.is_hidden and p.actual_type == PieceType.ROOK
+                        ]
+                        if my_rooks:
+                            score += 30
+
+        return score
+
+    def _count_moves(self, board: SimulationBoard, color: Color) -> int:
+        """统计可用走法数量"""
+        try:
+            moves = board.get_legal_moves(color)
+            return len(moves)
+        except Exception:
+            return 0
+
+    def normalize_score(self, raw_score: float) -> float:
+        """将原始分数归一化到 -1000 到 1000 范围
+
+        使用 tanh 函数平滑压缩
+        """
+        # 杀棋分数直接映射到边界
+        if raw_score >= self.MATE_SCORE:
+            return 1000.0
+        if raw_score <= -self.MATE_SCORE:
+            return -1000.0
+
+        # 使用 tanh 压缩
+        return math.tanh(raw_score / self.SCORE_SCALE) * 1000.0
+
+    def score_to_win_rate(self, normalized_score: float) -> float:
+        """将归一化分数转换为胜率
+
+        胜率范围: 0.0 到 1.0
+        0.5 表示均势
+        """
+        # 使用 sigmoid 函数
+        # normalized_score 在 -1000 到 1000 之间
+        # 我们希望 ±500 大约对应 75%/25% 胜率
+        return 1.0 / (1.0 + math.exp(-normalized_score / 200.0))
+
+    def win_rate_to_score(self, win_rate: float) -> float:
+        """将胜率转换回归一化分数
+
+        胜率范围: 0.0 到 1.0
+        返回: -1000 到 1000
+        """
+        if win_rate <= 0.0:
+            return -1000.0
+        if win_rate >= 1.0:
+            return 1000.0
+
+        # 逆 sigmoid
+        return -200.0 * math.log(1.0 / win_rate - 1.0)
+
+    def format_evaluation(self, board: SimulationBoard, color: Color) -> dict:
+        """格式化评估结果
+
+        返回包含多种表示的评估字典
+        """
+        raw_score = self.evaluate(board, color)
+        normalized = self.normalize_score(raw_score)
+        win_rate = self.score_to_win_rate(normalized)
+
+        return {
+            "raw_score": raw_score,
+            "normalized_score": round(normalized, 1),
+            "win_rate": round(win_rate * 100, 1),  # 百分比
+            "evaluation": self._score_to_text(normalized),
+        }
+
+    def _score_to_text(self, normalized_score: float) -> str:
+        """将分数转换为文字描述"""
+        if normalized_score >= 800:
+            return "决定性优势"
+        elif normalized_score >= 500:
+            return "明显优势"
+        elif normalized_score >= 200:
+            return "轻微优势"
+        elif normalized_score >= -200:
+            return "均势"
+        elif normalized_score >= -500:
+            return "轻微劣势"
+        elif normalized_score >= -800:
+            return "明显劣势"
+        else:
+            return "决定性劣势"
+
+
+# 全局评估器实例
+_evaluator: JieqiEvaluator | None = None
+
+
+def get_evaluator() -> JieqiEvaluator:
+    """获取全局评估器实例"""
+    global _evaluator
+    if _evaluator is None:
+        _evaluator = JieqiEvaluator()
+    return _evaluator

--- a/backend/jieqi/ai/strategies/__init__.py
+++ b/backend/jieqi/ai/strategies/__init__.py
@@ -16,6 +16,7 @@
 - v012_alphabeta: Alpha-Beta + TT AI
 - v013_iterative: 迭代加深搜索 AI
 - v014_advanced: 高级搜索 AI
+- v016_muses: Muses 风格 AI（参考揭棋 AI 大师思路）
 """
 
 # 导入所有策略以触发注册
@@ -33,3 +34,4 @@ from jieqi.ai.strategies.v011_minimax import strategy as v011  # noqa: F401
 from jieqi.ai.strategies.v012_alphabeta import strategy as v012  # noqa: F401
 from jieqi.ai.strategies.v013_iterative import strategy as v013  # noqa: F401
 from jieqi.ai.strategies.v014_advanced import strategy as v014  # noqa: F401
+from jieqi.ai.strategies.v016_muses import strategy as v016  # noqa: F401

--- a/backend/jieqi/ai/strategies/v016_muses/__init__.py
+++ b/backend/jieqi/ai/strategies/v016_muses/__init__.py
@@ -1,0 +1,9 @@
+"""
+v016_muses - Muses-inspired AI Strategy
+
+参考 miaosisrai 的揭棋 AI 实现
+"""
+
+from jieqi.ai.strategies.v016_muses.strategy import MusesAI
+
+__all__ = ["MusesAI"]

--- a/backend/jieqi/ai/strategies/v016_muses/strategy.py
+++ b/backend/jieqi/ai/strategies/v016_muses/strategy.py
@@ -1,0 +1,540 @@
+"""
+v016_muses - Muses-inspired AI Strategy
+
+ID: v016
+名称: Muses AI
+描述: 参考 miaosisrai 揭棋 AI 的 PVS 搜索和评估思路
+
+核心特性：
+1. Principal Variation Search (PVS) - 主变搜索
+2. 统一评分系统 (-1000 到 1000)
+3. 胜率输出功能
+4. 揭棋特有战术评估
+5. 暗子期望价值计算
+6. Quiescence Search (静态搜索) - 避免水平线效应
+
+注意：AI 使用 PlayerView，无法看到暗子的真实身份！
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import TYPE_CHECKING
+
+from jieqi.ai.base import AIConfig, AIEngine, AIStrategy
+from jieqi.ai.evaluator import JieqiEvaluator, get_evaluator
+from jieqi.simulation import SimulationBoard, SimPiece
+from jieqi.types import ActionType, Color, JieqiMove, PieceType, Position
+
+if TYPE_CHECKING:
+    from jieqi.view import PlayerView
+
+
+AI_ID = "v016"
+AI_NAME = "muses"
+
+
+class TTFlag(IntEnum):
+    """Transposition Table 节点类型"""
+
+    EXACT = 0
+    LOWERBOUND = 1
+    UPPERBOUND = 2
+
+
+@dataclass
+class TTEntry:
+    """Transposition Table 条目"""
+
+    hash_key: int
+    depth: int
+    score: float
+    flag: TTFlag
+    best_move: JieqiMove | None
+
+
+class TranspositionTable:
+    """Transposition Table 实现"""
+
+    def __init__(self, max_size: int = 500000):
+        self.max_size = max_size
+        self.table: dict[int, TTEntry] = {}
+        self.hits = 0
+        self.misses = 0
+
+    def get(self, hash_key: int) -> TTEntry | None:
+        entry = self.table.get(hash_key)
+        if entry:
+            self.hits += 1
+        else:
+            self.misses += 1
+        return entry
+
+    def store(
+        self,
+        hash_key: int,
+        depth: int,
+        score: float,
+        flag: TTFlag,
+        best_move: JieqiMove | None,
+    ) -> None:
+        old = self.table.get(hash_key)
+        if old is not None:
+            # 保留更深的精确值
+            if old.depth > depth and old.flag == TTFlag.EXACT:
+                return
+
+        if len(self.table) >= self.max_size:
+            # 清理老条目
+            if len(self.table) > self.max_size * 0.9:
+                to_delete = list(self.table.keys())[: self.max_size // 4]
+                for k in to_delete:
+                    del self.table[k]
+
+        self.table[hash_key] = TTEntry(hash_key, depth, score, flag, best_move)
+
+    def clear(self) -> None:
+        self.table.clear()
+        self.hits = 0
+        self.misses = 0
+
+
+@AIEngine.register(AI_NAME)
+class MusesAI(AIStrategy):
+    """Muses AI - 参考 miaosisrai 的揭棋 AI
+
+    使用 PVS 搜索和揭棋专用评估函数
+    """
+
+    name = AI_NAME
+    ai_id = AI_ID
+    description = "Muses 风格 AI (v016) - 参考揭棋 AI 大师思路"
+
+    # 搜索参数
+    DEFAULT_DEPTH = 5
+    MAX_DEPTH = 30
+    QS_DEPTH_LIMIT = 4  # 静态搜索最大深度
+
+    # LMR 参数
+    LMR_FULL_DEPTH_MOVES = 4
+    LMR_REDUCTION_LIMIT = 3
+
+    # 分数常量
+    MATE_SCORE = 10000
+
+    def __init__(self, config: AIConfig | None = None):
+        super().__init__(config)
+        self.time_limit = self.config.time_limit or 2.0
+        if self.config.time_limit:
+            self.max_depth = self.MAX_DEPTH
+        else:
+            self.max_depth = max(self.config.depth, self.DEFAULT_DEPTH)
+
+        self._rng = random.Random(self.config.seed)
+        self._tt = TranspositionTable()
+        self._evaluator = get_evaluator()
+        self._nodes_evaluated = 0
+        self._history: dict[tuple[Position, Position], int] = {}
+        self._killers: list[list[JieqiMove]] = [[] for _ in range(50)]
+        self._start_time = 0.0
+        self._best_move_at_depth: dict[int, tuple[JieqiMove, float]] = {}
+        self._pv_line: list[JieqiMove] = []
+
+    def select_move(self, view: PlayerView) -> JieqiMove | None:
+        """选择最佳走法"""
+        candidates = self.select_moves(view, n=1)
+        return candidates[0][0] if candidates else None
+
+    def select_moves(self, view: PlayerView, n: int = 10) -> list[tuple[JieqiMove, float]]:
+        """返回 Top-N 候选着法及其评分
+
+        分数已归一化到 -1000 到 1000 范围
+        """
+        if not view.legal_moves:
+            return []
+
+        if len(view.legal_moves) == 1:
+            return [(view.legal_moves[0], 0.0)]
+
+        my_color = view.viewer
+        sim_board = SimulationBoard(view)
+
+        self._nodes_evaluated = 0
+        self._start_time = time.time()
+        self._best_move_at_depth.clear()
+        self._pv_line.clear()
+
+        all_scores: dict[JieqiMove, float] = {}
+        last_complete_depth = 0
+
+        # 迭代加深搜索
+        for depth in range(1, self.max_depth + 1):
+            if depth > 1 and time.time() - self._start_time > self.time_limit * 0.7:
+                break
+
+            try:
+                scores = self._search_root_all(sim_board, view.legal_moves, depth, my_color)
+                if scores:
+                    all_scores = scores
+                    last_complete_depth = depth
+                    best_move = max(scores, key=scores.get)  # type: ignore
+                    best_score = scores[best_move]
+                    self._best_move_at_depth[depth] = (best_move, best_score)
+            except TimeoutError:
+                break
+
+        if not all_scores:
+            # 超时没结果，随机选择
+            shuffled = view.legal_moves[:]
+            self._rng.shuffle(shuffled)
+            return [(move, 0.0) for move in shuffled[:n]]
+
+        # 按分数排序并归一化
+        sorted_moves = sorted(all_scores.items(), key=lambda x: -x[1])
+        result = [
+            (move, self._evaluator.normalize_score(score)) for move, score in sorted_moves[:n]
+        ]
+
+        return result
+
+    def get_evaluation(self, view: PlayerView) -> dict:
+        """获取当前局面评估
+
+        返回包含分数和胜率的详细评估信息
+        """
+        sim_board = SimulationBoard(view)
+        return self._evaluator.format_evaluation(sim_board, view.viewer)
+
+    def _search_root_all(
+        self,
+        board: SimulationBoard,
+        legal_moves: list[JieqiMove],
+        depth: int,
+        color: Color,
+    ) -> dict[JieqiMove, float]:
+        """根节点搜索，返回所有走法的评分"""
+        position_hash = board.get_position_hash()
+        tt_entry = self._tt.get(position_hash)
+
+        prev_best = None
+        if depth - 1 in self._best_move_at_depth:
+            prev_best = self._best_move_at_depth[depth - 1][0]
+
+        sorted_moves = self._order_moves(board, legal_moves, color, 0, tt_entry, prev_best)
+
+        scores: dict[JieqiMove, float] = {}
+        alpha = float("-inf")
+        beta = float("inf")
+
+        for i, move in enumerate(sorted_moves):
+            if time.time() - self._start_time > self.time_limit:
+                raise TimeoutError()
+
+            piece = board.get_piece(move.from_pos)
+            if piece is None:
+                continue
+
+            was_hidden = piece.is_hidden
+            captured = board.make_move(move)
+
+            # 吃将直接返回最高分
+            if captured and captured.actual_type == PieceType.KING:
+                board.undo_move(move, captured, was_hidden)
+                scores[move] = self.MATE_SCORE
+                continue
+
+            # PVS 搜索
+            if i == 0:
+                score = -self._pvs(board, depth - 1, -beta, -alpha, color.opposite, 1, True)
+            else:
+                # 窄窗口搜索
+                score = -self._pvs(board, depth - 1, -alpha - 1, -alpha, color.opposite, 1, False)
+                if alpha < score < beta:
+                    # 重新搜索
+                    score = -self._pvs(board, depth - 1, -beta, -score, color.opposite, 1, True)
+
+            board.undo_move(move, captured, was_hidden)
+            scores[move] = score
+            alpha = max(alpha, score)
+
+        return scores
+
+    def _pvs(
+        self,
+        board: SimulationBoard,
+        depth: int,
+        alpha: float,
+        beta: float,
+        color: Color,
+        ply: int,
+        is_pv: bool,
+    ) -> float:
+        """Principal Variation Search"""
+        self._nodes_evaluated += 1
+
+        if self._nodes_evaluated % 2000 == 0:
+            if time.time() - self._start_time > self.time_limit:
+                raise TimeoutError()
+
+        alpha_orig = alpha
+        position_hash = board.get_position_hash()
+
+        # TT 查找
+        tt_entry = self._tt.get(position_hash)
+        if tt_entry is not None and tt_entry.depth >= depth and not is_pv:
+            if tt_entry.flag == TTFlag.EXACT:
+                return tt_entry.score
+            elif tt_entry.flag == TTFlag.LOWERBOUND:
+                alpha = max(alpha, tt_entry.score)
+            elif tt_entry.flag == TTFlag.UPPERBOUND:
+                beta = min(beta, tt_entry.score)
+
+            if alpha >= beta:
+                return tt_entry.score
+
+        # 终局检查
+        if board.find_king(color) is None:
+            return -self.MATE_SCORE + ply
+        if board.find_king(color.opposite) is None:
+            return self.MATE_SCORE - ply
+
+        # 叶子节点 - 使用静态搜索
+        if depth <= 0:
+            return self._quiescence(board, alpha, beta, color, ply, 0)
+
+        # 获取走法
+        legal_moves = board.get_legal_moves(color)
+        if not legal_moves:
+            if board.is_in_check(color):
+                return -self.MATE_SCORE + ply
+            return 0  # 和棋
+
+        # 走法排序
+        sorted_moves = self._order_moves(board, legal_moves, color, ply, tt_entry)
+
+        best_score = float("-inf")
+        best_move = None
+        in_check = board.is_in_check(color)
+
+        for i, move in enumerate(sorted_moves):
+            piece = board.get_piece(move.from_pos)
+            if piece is None:
+                continue
+
+            was_hidden = piece.is_hidden
+            captured = board.make_move(move)
+
+            # 吃将
+            if captured and captured.actual_type == PieceType.KING:
+                board.undo_move(move, captured, was_hidden)
+                return self.MATE_SCORE - ply
+
+            # Late Move Reduction
+            new_depth = depth - 1
+            if (
+                i >= self.LMR_FULL_DEPTH_MOVES
+                and depth >= self.LMR_REDUCTION_LIMIT
+                and captured is None
+                and not in_check
+                and not was_hidden
+            ):
+                reduction = 1 if i < 10 else 2
+                new_depth = max(1, depth - 1 - reduction)
+
+            # PVS 搜索
+            if i == 0 or not is_pv:
+                score = -self._pvs(board, new_depth, -beta, -alpha, color.opposite, ply + 1, is_pv)
+            else:
+                score = -self._pvs(
+                    board, new_depth, -alpha - 1, -alpha, color.opposite, ply + 1, False
+                )
+                if alpha < score < beta:
+                    score = -self._pvs(
+                        board, depth - 1, -beta, -score, color.opposite, ply + 1, True
+                    )
+
+            board.undo_move(move, captured, was_hidden)
+
+            if score > best_score:
+                best_score = score
+                best_move = move
+
+            alpha = max(alpha, score)
+
+            if alpha >= beta:
+                if captured is None:
+                    self._update_killers(move, ply)
+                    self._update_history(move, depth)
+                break
+
+        # 存储 TT
+        if best_score <= alpha_orig:
+            flag = TTFlag.UPPERBOUND
+        elif best_score >= beta:
+            flag = TTFlag.LOWERBOUND
+        else:
+            flag = TTFlag.EXACT
+
+        self._tt.store(position_hash, depth, best_score, flag, best_move)
+
+        return best_score
+
+    def _quiescence(
+        self,
+        board: SimulationBoard,
+        alpha: float,
+        beta: float,
+        color: Color,
+        ply: int,
+        qs_depth: int,
+    ) -> float:
+        """静态搜索 - 避免水平线效应
+
+        只搜索吃子走法，直到局面稳定
+        """
+        # 使用评估器获取评分
+        stand_pat = self._evaluator.evaluate(board, color)
+
+        if stand_pat >= beta:
+            return beta
+
+        if alpha < stand_pat:
+            alpha = stand_pat
+
+        # 深度限制
+        if qs_depth >= self.QS_DEPTH_LIMIT:
+            return stand_pat
+
+        # 只搜索吃子走法
+        captures = self._get_captures(board, color)
+
+        # MVV-LVA 排序
+        captures.sort(key=lambda m: self._mvv_lva_score(board, m), reverse=True)
+
+        for move in captures:
+            piece = board.get_piece(move.from_pos)
+            if piece is None:
+                continue
+
+            was_hidden = piece.is_hidden
+            captured = board.make_move(move)
+
+            if captured and captured.actual_type == PieceType.KING:
+                board.undo_move(move, captured, was_hidden)
+                return self.MATE_SCORE - ply
+
+            score = -self._quiescence(board, -beta, -alpha, color.opposite, ply + 1, qs_depth + 1)
+
+            board.undo_move(move, captured, was_hidden)
+
+            if score >= beta:
+                return beta
+
+            if score > alpha:
+                alpha = score
+
+        return alpha
+
+    def _get_captures(self, board: SimulationBoard, color: Color) -> list[JieqiMove]:
+        """只获取吃子走法"""
+        captures = []
+        for piece in board.get_all_pieces(color):
+            action_type = ActionType.REVEAL_AND_MOVE if piece.is_hidden else ActionType.MOVE
+            was_hidden = piece.is_hidden
+
+            for to_pos in board.get_potential_moves(piece):
+                target = board.get_piece(to_pos)
+                if target is None or target.color == color:
+                    continue
+
+                move = JieqiMove(action_type, piece.position, to_pos)
+                captured = board.make_move(move)
+                in_check = board.is_in_check(color)
+                board.undo_move(move, captured, was_hidden)
+                if not in_check:
+                    captures.append(move)
+
+        return captures
+
+    def _mvv_lva_score(self, board: SimulationBoard, move: JieqiMove) -> int:
+        """MVV-LVA 分数计算"""
+        target = board.get_piece(move.to_pos)
+        piece = board.get_piece(move.from_pos)
+
+        if target is None:
+            return 0
+
+        victim_value = int(self._evaluator.get_piece_value(target))
+        attacker_value = int(self._evaluator.get_piece_value(piece)) if piece else 0
+
+        return victim_value * 10 - attacker_value
+
+    def _order_moves(
+        self,
+        board: SimulationBoard,
+        moves: list[JieqiMove],
+        color: Color,
+        ply: int,
+        tt_entry: TTEntry | None = None,
+        prev_best: JieqiMove | None = None,
+    ) -> list[JieqiMove]:
+        """走法排序"""
+        scored_moves: list[tuple[float, JieqiMove]] = []
+        tt_best = tt_entry.best_move if tt_entry else None
+
+        for move in moves:
+            score = 0.0
+
+            # 上一次迭代的最佳走法
+            if prev_best and move == prev_best:
+                score += 20000000
+
+            # TT 最佳走法
+            if tt_best and move == tt_best:
+                score += 10000000
+
+            target = board.get_piece(move.to_pos)
+
+            # MVV-LVA
+            if target is not None and target.color != color:
+                score += 1000000 + self._mvv_lva_score(board, move)
+
+            # Killer moves
+            if ply < len(self._killers):
+                if move in self._killers[ply]:
+                    score += 500000
+
+            # 历史启发式
+            history_key = (move.from_pos, move.to_pos)
+            score += self._history.get(history_key, 0)
+
+            # 揭子走法有价值
+            if move.action_type == ActionType.REVEAL_AND_MOVE:
+                piece = board.get_piece(move.from_pos)
+                if piece:
+                    # 根据位置判断揭子价值
+                    if not move.to_pos.is_on_own_side(color):
+                        score += 300  # 过河揭子更有价值
+                    else:
+                        score += 100
+
+            scored_moves.append((score, move))
+
+        scored_moves.sort(key=lambda x: -x[0])
+        return [m for _, m in scored_moves]
+
+    def _update_killers(self, move: JieqiMove, ply: int) -> None:
+        if ply >= len(self._killers):
+            return
+        killers = self._killers[ply]
+        if move not in killers:
+            killers.insert(0, move)
+            if len(killers) > 2:
+                killers.pop()
+
+    def _update_history(self, move: JieqiMove, depth: int) -> None:
+        key = (move.from_pos, move.to_pos)
+        self._history[key] = self._history.get(key, 0) + depth * depth

--- a/backend/jieqi/api/models.py
+++ b/backend/jieqi/api/models.py
@@ -49,6 +49,21 @@ class PieceModel(BaseModel):
     type: str | None = None  # 只有明子才有
 
 
+class CapturedPieceModel(BaseModel):
+    """被吃棋子模型"""
+
+    color: str
+    type: str | None = None  # 明子有类型，暗子没有
+    was_hidden: bool = False  # 被吃时是否是暗子
+
+
+class CapturedPiecesModel(BaseModel):
+    """被吃棋子列表"""
+
+    red: list[CapturedPieceModel] = []  # 红方吃掉的棋子（黑方的棋子）
+    black: list[CapturedPieceModel] = []  # 黑方吃掉的棋子（红方的棋子）
+
+
 class CreateGameRequest(BaseModel):
     """创建游戏请求"""
 
@@ -105,6 +120,7 @@ class GameStateResponse(BaseModel):
     hidden_count: dict[str, int]
     mode: str
     delay_reveal: bool = False  # 是否为延迟分配模式
+    captured_pieces: CapturedPiecesModel | None = None  # 被吃的棋子
 
 
 class AIInfoResponse(BaseModel):

--- a/frontend/src/jieqi/JieqiApp.css
+++ b/frontend/src/jieqi/JieqiApp.css
@@ -14,6 +14,50 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  position: relative;
+}
+
+/* AI 思考中遮罩 */
+.ai-thinking-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 5px;
+  z-index: 100;
+}
+
+.ai-thinking-indicator {
+  background: rgba(255, 255, 255, 0.95);
+  padding: 16px 24px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 16px;
+  font-weight: 500;
+  color: #333;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.thinking-spinner {
+  width: 20px;
+  height: 20px;
+  border: 3px solid #ddd;
+  border-top-color: #4a90d9;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .controls-area {
@@ -21,7 +65,7 @@
   margin-left: 20px;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto auto 1fr;
   gap: 15px;
   min-width: 500px;
   max-height: calc(100vh - 40px);
@@ -38,9 +82,14 @@
   grid-row: 1;
 }
 
-.controls-area > .jieqi-history {
+.controls-area > .jieqi-captured {
   grid-column: 1 / -1;
   grid-row: 2;
+}
+
+.controls-area > .jieqi-history {
+  grid-column: 1 / -1;
+  grid-row: 3;
   overflow: hidden;
 }
 

--- a/frontend/src/jieqi/JieqiCaptured.css
+++ b/frontend/src/jieqi/JieqiCaptured.css
@@ -1,0 +1,95 @@
+/* 被吃棋子展示样式 */
+
+.jieqi-captured {
+  background: #f5f0e6;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 16px;
+  border: 1px solid #d4c4a8;
+}
+
+.captured-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.captured-section:last-child {
+  margin-bottom: 0;
+}
+
+.captured-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #5a4a3a;
+  min-width: 100px;
+}
+
+.captured-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.no-captured {
+  color: #999;
+  font-style: italic;
+}
+
+.captured-piece {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  font-size: 16px;
+  font-weight: bold;
+  border-radius: 50%;
+  border: 2px solid;
+  background: #f9f5e8;
+  cursor: default;
+  transition: transform 0.2s;
+}
+
+.captured-piece:hover {
+  transform: scale(1.1);
+}
+
+.captured-piece.red {
+  color: #c41e3a;
+  border-color: #c41e3a;
+}
+
+.captured-piece.black {
+  color: #1a1a1a;
+  border-color: #1a1a1a;
+}
+
+/* 暗子样式 - 添加问号图案背景 */
+.captured-piece.was-hidden {
+  background: linear-gradient(135deg, #e8e0d0 25%, #d8d0c0 75%);
+  opacity: 0.8;
+}
+
+.captured-piece.was-hidden.red {
+  border-style: dashed;
+}
+
+.captured-piece.was-hidden.black {
+  border-style: dashed;
+}
+
+/* 红方吃掉的区域强调 */
+.red-captured .captured-list {
+  background: rgba(26, 26, 26, 0.05);
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+/* 黑方吃掉的区域强调 */
+.black-captured .captured-list {
+  background: rgba(196, 30, 58, 0.05);
+  padding: 4px 8px;
+  border-radius: 4px;
+}

--- a/frontend/src/jieqi/JieqiCaptured.tsx
+++ b/frontend/src/jieqi/JieqiCaptured.tsx
@@ -1,0 +1,66 @@
+// 被吃棋子展示组件
+
+import type { CapturedPiece, Color } from './types';
+import { PIECE_NAMES, HIDDEN_PIECE_CHAR } from './types';
+import './JieqiCaptured.css';
+
+interface JieqiCapturedProps {
+  capturedPieces?: {
+    red: CapturedPiece[];
+    black: CapturedPiece[];
+  };
+}
+
+export function JieqiCaptured({ capturedPieces }: JieqiCapturedProps) {
+  if (!capturedPieces) {
+    return null;
+  }
+
+  const renderPiece = (piece: CapturedPiece, index: number) => {
+    const pieceColor = piece.color;
+    let displayChar: string;
+
+    if (piece.was_hidden || !piece.type) {
+      // 暗子显示为暗/闇
+      displayChar = HIDDEN_PIECE_CHAR[pieceColor];
+    } else {
+      // 明子显示真实棋子
+      displayChar = PIECE_NAMES[piece.type]?.[pieceColor] || '?';
+    }
+
+    return (
+      <span
+        key={index}
+        className={`captured-piece ${pieceColor} ${piece.was_hidden ? 'was-hidden' : ''}`}
+        title={piece.type ? piece.type : 'hidden piece'}
+      >
+        {displayChar}
+      </span>
+    );
+  };
+
+  const renderCapturedSection = (pieces: CapturedPiece[], capturedBy: Color) => {
+    if (pieces.length === 0) {
+      return <span className="no-captured">-</span>;
+    }
+
+    return (
+      <div className="captured-list">
+        {pieces.map((piece, index) => renderPiece(piece, index))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="jieqi-captured">
+      <div className="captured-section red-captured">
+        <span className="captured-label">Red captured:</span>
+        {renderCapturedSection(capturedPieces.red, 'red')}
+      </div>
+      <div className="captured-section black-captured">
+        <span className="captured-label">Black captured:</span>
+        {renderCapturedSection(capturedPieces.black, 'black')}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/jieqi/JieqiGameControls.tsx
+++ b/frontend/src/jieqi/JieqiGameControls.tsx
@@ -19,17 +19,17 @@ export function JieqiGameControls({
   onRequestAIMove,
   isLoading,
 }: JieqiGameControlsProps) {
-  const [mode, setMode] = useState<GameMode>('ai_vs_ai');
+  const [mode, setMode] = useState<GameMode>('human_vs_ai');  // 默认人机对战
   const [aiColor, setAIColor] = useState<string>('black');
-  const [aiStrategy, setAIStrategy] = useState<string>('greedy');
-  const [redAIStrategy, setRedAIStrategy] = useState<string>('greedy');
-  const [blackAIStrategy, setBlackAIStrategy] = useState<string>('random');
+  const [aiStrategy, setAIStrategy] = useState<string>('muses');  // 默认最强 AI
+  const [redAIStrategy, setRedAIStrategy] = useState<string>('muses');
+  const [blackAIStrategy, setBlackAIStrategy] = useState<string>('muses');
   const [delayReveal, setDelayReveal] = useState<boolean>(true);  // 默认开启延迟分配模式
 
   // AI 思考时间限制
-  const [aiTimeLimit, setAITimeLimit] = useState<AITimeLimit>(5);
-  const [redAITimeLimit, setRedAITimeLimit] = useState<AITimeLimit>(5);
-  const [blackAITimeLimit, setBlackAITimeLimit] = useState<AITimeLimit>(5);
+  const [aiTimeLimit, setAITimeLimit] = useState<AITimeLimit>(15);  // 默认 15 秒
+  const [redAITimeLimit, setRedAITimeLimit] = useState<AITimeLimit>(15);
+  const [blackAITimeLimit, setBlackAITimeLimit] = useState<AITimeLimit>(15);
 
   // AI 策略列表（从后端获取）
   const [aiStrategies, setAiStrategies] = useState<AIStrategyInfo[]>([]);
@@ -39,16 +39,14 @@ export function JieqiGameControls({
     getAIInfo()
       .then(info => {
         setAiStrategies(info.available_strategies);
-        // 设置默认策略
+        // 设置默认策略为最强的 muses，如果不存在则用 advanced
         if (info.available_strategies.length > 0) {
-          const defaultStrategy = info.available_strategies.find(s => s.name === 'greedy')?.name
+          const strongestStrategy = info.available_strategies.find(s => s.name === 'muses')?.name
+            || info.available_strategies.find(s => s.name === 'advanced')?.name
             || info.available_strategies[0].name;
-          setAIStrategy(defaultStrategy);
-          setRedAIStrategy(defaultStrategy);
-          // 黑方用 random 作为默认（用于对比测试）
-          const randomStrategy = info.available_strategies.find(s => s.name === 'random')?.name
-            || info.available_strategies[0].name;
-          setBlackAIStrategy(randomStrategy);
+          setAIStrategy(strongestStrategy);
+          setRedAIStrategy(strongestStrategy);
+          setBlackAIStrategy(strongestStrategy);
         }
       })
       .catch(err => console.error('Failed to load AI strategies:', err));

--- a/frontend/src/jieqi/types.ts
+++ b/frontend/src/jieqi/types.ts
@@ -41,6 +41,13 @@ export interface JieqiGameState {
     black: number;
   };
   delay_reveal: boolean;  // 是否为延迟分配模式
+  // 吃掉的棋子
+  captured_pieces?: {
+    red: CapturedPiece[];  // 红方吃掉的棋子（黑方的棋子）
+    black: CapturedPiece[];  // 黑方吃掉的棋子（红方的棋子）
+  };
+  // AI 正在思考
+  ai_thinking?: boolean;
 }
 
 export interface JieqiMoveResponse {
@@ -54,8 +61,15 @@ export interface JieqiMoveResponse {
 }
 
 // AI 思考时间选项
-export const AI_TIME_OPTIONS = [1, 3, 5, 15, 30] as const;
+export const AI_TIME_OPTIONS = [1, 3, 5, 10, 15, 30] as const;
 export type AITimeLimit = typeof AI_TIME_OPTIONS[number];
+
+// 吃掉的棋子
+export interface CapturedPiece {
+  color: Color;
+  type?: PieceType;  // 明子有类型，暗子没有
+  was_hidden: boolean;  // 被吃时是否是暗子
+}
 
 // 创建游戏请求
 export interface CreateJieqiGameOptions {


### PR DESCRIPTION
## 概述
改进揭棋前端用户界面和AI对战体验。

## 主要变更

### 前端改进
- 默认游戏模式改为人机对战（Human vs AI）
- 默认AI策略改为muses（最强策略），思考时间15秒
- 人下完棋后先显示走棋效果，再让AI思考（分离API调用，300ms延迟）
- 添加吃子展示功能，显示双方吃掉的棋子（暗子显示为暗/闇，明子显示真实棋子）
- 添加AI思考中的loading提示

### 后端改进
- 修改 /move 端点，不再自动执行AI走棋，让前端控制时机
- 添加 captured_pieces 到游戏状态响应中
- 新增 CapturedPieceModel 和 CapturedPiecesModel 数据模型

### 新增AI模块
- 新增 v016_muses AI策略
- 新增统一评估器模块 (evaluator.py)，标准化评分范围 (-1000 到 1000)

## 测试
- [x] 后端导入正常
- [x] TypeScript 编译无错误
- [x] 吃子功能测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)